### PR TITLE
Default label color

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
             targets: ["ResponsiveTextField"]),
     ],
     dependencies: [
-        .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2"),
-        .package(name: "combine-schedulers", url: "https://github.com/pointfreeco/combine-schedulers.git", from: "1.0.2")
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2"),
+        .package(url: "https://github.com/pointfreeco/combine-schedulers.git", from: "1.0.2")
     ],
     targets: [
         .target(

--- a/Sources/ResponsiveTextField/ResponsiveTextField+EnvironmentValues.swift
+++ b/Sources/ResponsiveTextField/ResponsiveTextField+EnvironmentValues.swift
@@ -24,7 +24,7 @@ extension ResponsiveTextField {
     }
 
     fileprivate struct TextColorKey: EnvironmentKey {
-        static let defaultValue: UIColor = .black
+        static let defaultValue: UIColor = .label
     }
 
     fileprivate struct TextAlignmentKey: EnvironmentKey {


### PR DESCRIPTION
- Fixes #22 
- Remove a warning about using a deprecated `.package` method that showed up in Xcode 26.